### PR TITLE
Added Verbose Option

### DIFF
--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -389,7 +389,7 @@ class FortiManager(object):
             json_request["id"] = self.req_id
         else:
             json_request["method"] = method
-            if method == "get" and self._verbose:
+            if method == "get" and self._verbose is True:
                 json_request["verbose"] = 1
             json_request["params"] = params
             json_request["session"] = self.sid

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -391,7 +391,7 @@ class FortiManager(object):
             json_request["method"] = method
             json_request["params"] = params
             if self._verbose:
-                params[0].update({"verbose": "True"})
+                json_request["verbose"] = self._verbose
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
         self.req_resp_object.request_json = json_request

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -391,6 +391,7 @@ class FortiManager(object):
             json_request["method"] = method
             if method == "get" and self._verbose is True:
                 json_request["verbose"] = 1
+                print("SETTING VERBOSE")
             json_request["params"] = params
             json_request["session"] = self.sid
             json_request["id"] = self.req_id

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -389,9 +389,9 @@ class FortiManager(object):
             json_request["id"] = self.req_id
         else:
             json_request["method"] = method
-            json_request["params"] = params
-            if self._verbose:
+            if method == "get" and self._verbose:
                 json_request["verbose"] = 1
+            json_request["params"] = params
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
         self.req_resp_object.request_json = json_request

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -208,7 +208,7 @@ class RequestResponse(object):
 class FortiManager(object):
 
     def __init__(self, host=None, user="", passwd="", debug=False, use_ssl=True, verify_ssl=False, timeout=300,
-                 disable_request_warnings=False):
+                 verbose=False, disable_request_warnings=False):
         super(FortiManager, self).__init__()
         self._debug = debug
         self._host = host
@@ -217,6 +217,7 @@ class FortiManager(object):
         self._use_ssl = use_ssl
         self._verify_ssl = verify_ssl
         self._timeout = timeout
+        self._verbose = verbose
         self._req_id = 0
         self._sid = None
         self._url = None
@@ -269,6 +270,14 @@ class FortiManager(object):
     @timeout.setter
     def timeout(self, val):
         self._timeout = val
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, val):
+        self._verbose = val
 
     @property
     def sess(self):
@@ -497,6 +506,8 @@ class FortiManager(object):
     @staticmethod
     def common_datagram_params(method_type, url, *args, **kwargs):
         params = [{"url": url}]
+        if self._verbose:
+            params[0].update("verbose": "True")
         if args:
             for arg in args:
                 params[0].update(arg)

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -391,7 +391,7 @@ class FortiManager(object):
             json_request["method"] = method
             json_request["params"] = params
             if self._verbose:
-                json_request["verbose"] = self._verbose
+                json_request["verbose"] = 1
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
         self.req_resp_object.request_json = json_request

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -390,6 +390,8 @@ class FortiManager(object):
         else:
             json_request["method"] = method
             json_request["params"] = params
+            if self._verbose:
+                params[0].update({"verbose": "True"})
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
         self.req_resp_object.request_json = json_request
@@ -506,8 +508,6 @@ class FortiManager(object):
     @staticmethod
     def common_datagram_params(method_type, url, *args, **kwargs):
         params = [{"url": url}]
-        if self._verbose:
-            params[0].update({"verbose": "True"})
         if args:
             for arg in args:
                 params[0].update(arg)

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -507,7 +507,7 @@ class FortiManager(object):
     def common_datagram_params(method_type, url, *args, **kwargs):
         params = [{"url": url}]
         if self._verbose:
-            params[0].update("verbose": "True")
+            params[0].update({"verbose": "True"})
         if args:
             for arg in args:
                 params[0].update(arg)

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -389,10 +389,9 @@ class FortiManager(object):
             json_request["id"] = self.req_id
         else:
             json_request["method"] = method
-            if method == "get" and self._verbose is True:
-                json_request["verbose"] = 1
-                print("SETTING VERBOSE")
             json_request["params"] = params
+            if method is "get" and self._verbose is True:
+                json_request["verbose"] = 1
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
         self.req_resp_object.request_json = json_request


### PR DESCRIPTION
Added an option in the FortiManager class to enable the "Verbose" option when creating the object.  If enabled, the verbose setting is added to the JSON Params and included in all calls made to the FMG. The option will only really provide value on "get" calls as it will return the "human readable" version of the data, but it does not have a negative impact on any of the other methods tested so far, including add, update, and execute and it works without issue on the Freeform call as well.