### PR TITLE
Update fortimgr.py

### DIFF
--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -543,6 +543,7 @@ class FortiManager(object):
             json_request["params"] = params
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
+            json_request["jsonrpc"] = "2.0"
         else:
             json_request["method"] = method
             json_request["params"] = params
@@ -550,6 +551,7 @@ class FortiManager(object):
                 json_request["verbose"] = 1
             json_request["session"] = self.sid
             json_request["id"] = self.req_id
+            json_request["jsonrpc"] = "2.0"
         self.req_resp_object.request_json = json_request
         try:
             response = self.sess.post(self._url, data=json.dumps(json_request), verify=self.verify_ssl,


### PR DESCRIPTION
To use the faz.free_form function. We need to include the  jsonrpc version in the API call. n this file we need to locate the _post_request function and add two lines like below: "json_request["jsonrpc"] = "2.0""