### PR TITLE
Changed check_mode function to work with verbose and non-verbose mode

### DIFF
--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -109,12 +109,12 @@ class FMGLockContext(object):
         url = "/cli/global/system/global"
         code, resp_obj = self._fmg.get(url, fields=["workspace-mode", "adom-status"])
         try:
-            if resp_obj["workspace-mode"] != 0:
+            if resp_obj["workspace-mode"] not in [0, "disabled"]:
                 self.uses_workspace = True
         except KeyError:
             self.uses_workspace = False
         try:
-            if resp_obj["adom-status"] == 1:
+            if resp_obj["adom-status"] in [1, "enable"]:
                 self.uses_adoms = True
         except KeyError:
             self.uses_adoms = False


### PR DESCRIPTION
Currently pyFMG does not set the correct state for self._lock_ctx.use_adoms or self._lock_ctx.uses_workspace whenever verbose mode is set to True.  With verbose=True, FMG will respond with text statuses instead of integers. pyFMG is only checking the integer value of the statuses

Here is quick implementation check that i ran before the modification with verbose=True

```python
with FortiManager(server_host, username, password, verify_ssl=verify_ssl, debug=debug, verbose=verbose,
                  disable_request_warnings=disable_request_warnings) as fmg:
    # Perform the desired action

    data = {"fields": ["workspace-mode", "adom-status"]}
    status, response = fmg.get('/cli/global/system/global', fields=data['fields'])
    print("Response workspace-mode: ", response['workspace-mode'])
    print("Response adom-status: ", response['adom-status'])
    print("fmg._lock_ctx.uses_adoms: ", fmg._lock_ctx.uses_adoms)
    print("fmg._lock_ctx.uses_workspace: ", fmg._lock_ctx.uses_workspace)
```
Output
```text
Response workspace-mode:  disabled
Response adom-status:  enable
fmg._lock_ctx.uses_adoms:  False
fmg._lock_ctx.uses_workspace:  True
```

After making the changes in this PR and rerunning the python, i get this output which correctly reflects the status

```text
Response workspace-mode:  disabled
Response adom-status:  enable
fmg._lock_ctx.uses_adoms:  True
fmg._lock_ctx.uses_workspace:  False
```