### PR TITLE
Skip/bypass Fortimanager logout ("/sys/logout") when API key used for authentication.

### DIFF
--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -703,6 +703,9 @@ class FortiManager(object):
 
     def logout(self):
         if self.sid is not None:
+            if self.api_key_used:
+                self.sid = None
+                return
             if self._lock_ctx.uses_workspace:
                 self._lock_ctx.run_unlock()
             ret_code, response = self.execute("sys/logout")


### PR DESCRIPTION
Per Fortimanager documentation for using API key, the `login` and `logout` functions are not required when the API key used ([https://docs.fortinet.com/document/fortimanager/7.6.0/api-best-practices/140185/getting-started](https://docs.fortinet.com/document/fortimanager/7.6.0/api-best-practices/140185/getting-started)). Accordingly, in PyFMG, if the `self.api_key_used` flag is set/enabled (`True`), then it is not necessary to execute `/sys/logout` process. This change skips/bypasses that portion of process in the `logout()` method in such case.